### PR TITLE
Volumed and ephemeral builds

### DIFF
--- a/Dockerfile.ephemeral
+++ b/Dockerfile.ephemeral
@@ -13,7 +13,6 @@ RUN mkdir -p /minio \
  && chown 1001:0 -R /minio \
  && chmod -R g+rwX  /minio
 
-VOLUME ["/minio/data", "/minio/config"]
 EXPOSE 9000
 
 USER 1001


### PR DESCRIPTION
Volumes were removed back in 7e813ef6a244863cb6e32192f90179f0009eb3bb to support images that capture data.  Need pvc mappings now, going to keep both builds.

For now just duplicating the dockerfiles.